### PR TITLE
[svg2xml] fix destination path of generated files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,11 @@
             <version>4.1.0</version>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.7</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.5.2</version>

--- a/src/main/java/com/mxgraph/utils/FileUtils.java
+++ b/src/main/java/com/mxgraph/utils/FileUtils.java
@@ -1,0 +1,23 @@
+package com.mxgraph.utils;
+
+import java.io.File;
+import java.io.IOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.lines;
+import static java.util.stream.Collectors.joining;
+
+public class FileUtils {
+
+    public static final String EOL = System.lineSeparator();
+
+    // when switching to JDK11+, use Files#readString instead
+    public static String fileContent(File file) {
+        try {
+            return lines(file.toPath(), UTF_8).collect(joining(EOL));
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to read the content of " + file, e);
+        }
+    }
+
+}

--- a/src/main/java/com/mxgraph/xml2js/Xml2Js.java
+++ b/src/main/java/com/mxgraph/xml2js/Xml2Js.java
@@ -9,12 +9,12 @@ import org.xml.sax.InputSource;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.File;
-import java.io.IOException;
 import java.io.StringReader;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.mxgraph.utils.FileUtils.EOL;
+import static com.mxgraph.utils.FileUtils.fileContent;
 import static java.lang.String.format;
 
 public class Xml2Js {
@@ -51,18 +51,6 @@ public class Xml2Js {
         String code = parse(fileContent);
         logInfo("Parsing completed");
         return code;
-    }
-
-    public static final String EOL = System.getProperty("line.separator");
-
-    private static String fileContent(File file) {
-        // TODO java 11 use readString
-        try {
-            List<String> strings = Files.readAllLines(file.toPath());
-            return String.join(EOL, strings);
-        } catch (IOException e) {
-            throw new RuntimeException("Unable to read the content of " + file, e);
-        }
     }
 
     private String parse(String shapeStencilXml) {

--- a/src/test/java/com/mxgraph/svg2xml/Svg2XmlTest.java
+++ b/src/test/java/com/mxgraph/svg2xml/Svg2XmlTest.java
@@ -1,0 +1,97 @@
+package com.mxgraph.svg2xml;
+
+import static com.mxgraph.utils.FileUtils.EOL;
+import static com.mxgraph.utils.FileUtils.fileContent;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import java.io.File;
+import java.util.Arrays;
+
+class Svg2XmlTest {
+
+    @Test
+    void convertToXml_single_file() {
+        Svg2Xml svg2Xml = new Svg2Xml();
+
+        File destPath = destinationFolder("Simple-Single file");
+        svg2Xml.convertToXml(svgSourceFiles("simple-01/circle-green.svg"), destPath);
+
+        File expectedGeneratedFile = new File(destPath, "circle-green.xml");
+        assertThat(expectedGeneratedFile).isFile();
+        String fileContent = fileContent(expectedGeneratedFile);
+        assertThat(fileContent).startsWith("<shapes name=\"mxgraph.simple-01\">");
+        assertThat(fileContent).contains(
+                "<fillcolor color=\"green\"/>",
+                "<ellipse h=\"200\" w=\"200\" x=\"0\" y=\"0\"/>"
+        );
+    }
+
+    @Test
+    void convertToXml_two_files_from_the_same_folder() {
+        Svg2Xml svg2Xml = new Svg2Xml();
+
+        File destPath = destinationFolder("Simple-Two files");
+        svg2Xml.convertToXml(svgSourceFiles("simple-01/circle-green.svg", "simple-01/rectangle-blue.svg"), destPath);
+
+        File expectedGeneratedFile = new File(destPath, "rectangle-blue.xml"); // use base name of the latest svg file in the source folder
+        assertThat(expectedGeneratedFile).isFile();
+        String fileContent = fileContent(expectedGeneratedFile);
+        assertThat(fileContent).startsWith("<shapes name=\"mxgraph.simple-01\">");
+        assertThat(fileContent).contains(
+                // 1st shape
+                "<shape aspect=\"variable\" h=\"200\" name=\"circle-green\"",
+                // 2nde shape
+                "<shape aspect=\"variable\" h=\"100\" name=\"rectangle-blue\""
+        );
+    }
+
+    @Test
+    void convertToXml_files_from_two_folders_without_subfolders_files_given_ordered_by_folders() {
+        Svg2Xml svg2Xml = new Svg2Xml();
+
+        File destPath = destinationFolder("files from 2 folders - no subfolders");
+        // in the current implementation, the files are supposed to be passed ordered by folder
+        svg2Xml.convertToXml(svgSourceFiles("simple-01/circle-green.svg", "simple-01/rectangle-blue.svg", "simple-02/path-blue.svg"), destPath);
+
+
+        // File generated from source files in 'simple-01'
+        File expected1stGeneratedFile = new File(destPath, "rectangle-blue.xml");
+        assertThat(expected1stGeneratedFile).isFile();
+        String contentOfFirstFile = fileContent(expected1stGeneratedFile);
+        assertThat(contentOfFirstFile).startsWith("<shapes name=\"mxgraph.simple-01\">");
+
+        // File generated from source files in 'simple-02'
+        File expected2ndGeneratedFile = new File(destPath, "path-blue.xml");
+        assertThat(expected2ndGeneratedFile).isFile();
+        String contentOf2ndFile = fileContent(expected2ndGeneratedFile);
+        assertThat(contentOf2ndFile).startsWith("<shapes name=\"mxgraph.simple-02\">");
+        assertThat(contentOf2ndFile).describedAs("Content of the 2nd generated file").contains(
+                "<quad x1=\"20\" x2=\"30\" y1=\"0\" y2=\"25\"/>",
+                "<quad x1=\"40\" x2=\"70\" y1=\"50\" y2=\"25\"/>"
+        );
+    }
+
+    // =================================================================================================================
+    // UTILS
+    // =================================================================================================================
+
+    private static void assertFirstLine(String fileContent, String expectedStart, String expectedEnd) {
+        String firstLine = fileContent.substring(0, fileContent.indexOf(EOL));
+        assertThat(firstLine).describedAs("1st line of the generated file")
+                .startsWith(expectedStart)
+                .endsWith(expectedEnd);
+    }
+
+    private static File[] svgSourceFiles(String... fileNames) {
+        File parent = new File(System.getProperty("user.dir"), "src/test/resources/svg"); // ensure we pass absolute path
+        return Arrays.stream(fileNames)
+                .map(fileName -> new File(parent, fileName))
+                .toArray(File[]::new);
+    }
+
+    private static File destinationFolder(String folderName) {
+        return new File("target/test/output/", folderName);
+    }
+
+}

--- a/src/test/resources/svg/simple-01/circle-green.svg
+++ b/src/test/resources/svg/simple-01/circle-green.svg
@@ -1,0 +1,3 @@
+<svg width="2000" height="2000" xmlns="http://www.w3.org/2000/svg">
+    <circle stroke="red" cx="150" cy="150" r="100" fill="green" />
+</svg>

--- a/src/test/resources/svg/simple-01/rectangle-blue.svg
+++ b/src/test/resources/svg/simple-01/rectangle-blue.svg
@@ -1,0 +1,3 @@
+<svg width="400" height="110" xmlns="http://www.w3.org/2000/svg">
+    <rect width="300" height="100" style="fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)" />
+</svg>

--- a/src/test/resources/svg/simple-01/subfolder-01/elipse-black.svg
+++ b/src/test/resources/svg/simple-01/subfolder-01/elipse-black.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" standalone="no"?>
+<svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <ellipse cx="75" cy="75" rx="20" ry="5" stroke="red" fill="transparent" stroke-width="5"/>
+</svg>

--- a/src/test/resources/svg/simple-01/subfolder-01/rectangle-black.svg
+++ b/src/test/resources/svg/simple-01/subfolder-01/rectangle-black.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" standalone="no"?>
+<svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <rect x="10" y="10" width="30" height="30" stroke="black" fill="transparent" stroke-width="5"/>
+</svg>

--- a/src/test/resources/svg/simple-01/subfolder-02/polyline-orange.svg
+++ b/src/test/resources/svg/simple-01/subfolder-02/polyline-orange.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" standalone="no"?>
+<svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <polyline points="60 110 65 120 70 115 75 130 80 125 85 140 90 135 95 150 100 145"
+              stroke="orange" fill="transparent" stroke-width="5"/>
+</svg>

--- a/src/test/resources/svg/simple-02/path-blue.svg
+++ b/src/test/resources/svg/simple-02/path-blue.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" standalone="no"?>
+<svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <path d="M20,230 Q40,205 50,230 T90,230" fill="none" stroke="blue" stroke-width="5"/>
+</svg>

--- a/src/test/resources/svg/simple-02/subfolder-01/circle-black.svg
+++ b/src/test/resources/svg/simple-02/subfolder-01/circle-black.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" standalone="no"?>
+<svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="25" cy="75" r="20" stroke="red" fill="transparent" stroke-width="5"/>
+</svg>

--- a/src/test/resources/svg/simple-02/subfolder-02/line-orange.svg
+++ b/src/test/resources/svg/simple-02/subfolder-02/line-orange.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" standalone="no"?>
+<svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <line x1="10" x2="50" y1="110" y2="150" stroke="orange" stroke-width="5"/>
+</svg>

--- a/src/test/resources/svg/simple-02/subfolder-02/rectangle-rounded-black.svg
+++ b/src/test/resources/svg/simple-02/subfolder-02/rectangle-rounded-black.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" standalone="no"?>
+<svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <rect x="60" y="10" rx="10" ry="10" width="30" height="30" stroke="black" fill="transparent" stroke-width="5"/>
+</svg>

--- a/src/test/resources/svg/simple-02/subfolder-02/star-green.svg
+++ b/src/test/resources/svg/simple-02/subfolder-02/star-green.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" standalone="no"?>
+<svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <polygon points="50 160 55 180 70 180 60 190 65 205 50 195 35 205 40 190 30 180 45 180"
+             stroke="green" fill="transparent" stroke-width="5"/>
+</svg>


### PR DESCRIPTION
Previous implementation was only designed to work on Windows OS
- the actual destination path was the concatenation of the provided destination path + the path of the parent of the source svg file. But it removed the first 2 letters from the parent source path (probably to manage the Windows drive)
- In addition, it put the whole path lower case, replace space by underscore, probably to work on old Windows versions that don't like space and mix cases when using the Command Prompt

On Linux (and probably all case-sensitive OS, so MacOS), this changed the destination folder a lot which made it very hard to find the generated file.

Changes done in this area in the upstream repo (commits ordered by date) and that have been integrated into `develop` on `2020-08-16`
- 2020-06-22
  - "Changed stencil group naming mechanism to be more intuitive" https://github.com/jgraph/svg2xml/commit/f0d2f734f2b25f083ac5e9511a89acf82d2a3d92
- 2020-06-24
  - "Fixes group name generating and option for naming from config ": https://github.com/jgraph/svg2xml/commit/b9058ba726e8a69247947d0e9d04f2c89020a31d
  - "Less folders are generated at destination ": https://github.com/jgraph/svg2xml/commit/1f232f5275daec4f4da5e1182171942e079abdcc

There was still an issue because the path was still put into lower-case that has been fixed.
Several tests have been added to verify that the generation works on all OS.