### PR TITLE
[xml2js] add support for quadTo and stroke

### DIFF
--- a/src/main/java/com/mxgraph/svg2xml/Svg2Xml.java
+++ b/src/main/java/com/mxgraph/svg2xml/Svg2Xml.java
@@ -106,7 +106,12 @@ public class Svg2Xml
 		svg2Xml.convertToXml(sourceFiles.toArray(new File[0]), new File(args[1]));
 	}
 
+	// TODO log management duplicated with Xml2Js
 	private boolean isInfoLogActivated = true;
+	public Svg2Xml infoLog(boolean activate) {
+		this.isInfoLogActivated = activate;
+		return this;
+	}
 	private void logInfo(String msg) {
 		if (isInfoLogActivated) {
 			System.out.println(format("Svg2Xml [INFO] %s", msg));

--- a/src/main/java/com/mxgraph/xml2js/Xml2Js.java
+++ b/src/main/java/com/mxgraph/xml2js/Xml2Js.java
@@ -132,6 +132,10 @@ public class Xml2Js {
                     case "path":
                         parsePath((Element) item);
                         break;
+                    case "stroke":
+                        logDebug("Parsing stroke");
+                        generateCanvasMethodCall("stroke()");
+                        break;
                     default:
                         logDebug("Unsupported element: " + nodeName);
                 }

--- a/src/main/java/com/mxgraph/xml2js/Xml2Js.java
+++ b/src/main/java/com/mxgraph/xml2js/Xml2Js.java
@@ -23,6 +23,7 @@ public class Xml2Js {
         }
 
         File source = new File(args[0]);
+        // TODO make log level configurable
         String code = new Xml2Js().infoLog(true).debugLog(false).parse(source);
         System.out.println(code);
     }
@@ -92,8 +93,11 @@ public class Xml2Js {
         for (int i = 0; i < shapeChildren.getLength(); i++) {
             Node item = shapeChildren.item(i);
             if (item.getNodeType() == Node.ELEMENT_NODE) {
-                if (item.getNodeName().equals("foreground")) {
+                String nodeName = item.getNodeName();
+                if (nodeName.equals("foreground")) {
                     parseForeground(item);
+                } else {
+                    logDebug("Unsupported element: " + nodeName);
                 }
             }
         }
@@ -127,6 +131,9 @@ public class Xml2Js {
                         break;
                     case "path":
                         parsePath((Element) item);
+                        break;
+                    default:
+                        logDebug("Unsupported element: " + nodeName);
                 }
             }
         }
@@ -183,7 +190,13 @@ public class Xml2Js {
             case "move":
                 generateCanvasMethodCall(format("moveTo(%s, %s)", element.getAttribute("x"), element.getAttribute("y")));
                 break;
-
+            case "quad":
+                generateCanvasMethodCall(format("quadTo(%s, %s, %s, %s)",
+                        element.getAttribute("x1"), element.getAttribute("y1"),
+                        element.getAttribute("x2"), element.getAttribute("y2")));
+                break;
+            default:
+                logDebug("Unsupported element: " + nodeName);
         }
     }
 

--- a/src/test/java/com/mxgraph/FileTooling.java
+++ b/src/test/java/com/mxgraph/FileTooling.java
@@ -1,0 +1,23 @@
+package com.mxgraph;
+
+import java.io.File;
+import java.util.Arrays;
+
+public class FileTooling {
+
+    public static File[] svgSourceFiles(String... fileNames) {
+        File parent = new File(System.getProperty("user.dir"), "src/test/resources/svg"); // ensure we pass absolute path
+        return Arrays.stream(fileNames)
+                .map(fileName -> new File(parent, fileName))
+                .toArray(File[]::new);
+    }
+
+    public static File svgSourceFile(String fileName) {
+        return svgSourceFiles(fileName)[0];
+    }
+
+    public static File destinationFolder(String folderName) {
+        return new File("target/test/output/", folderName);
+    }
+
+}

--- a/src/test/java/com/mxgraph/svg2js/Svg2JsTest.java
+++ b/src/test/java/com/mxgraph/svg2js/Svg2JsTest.java
@@ -1,0 +1,37 @@
+package com.mxgraph.svg2js;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static com.mxgraph.FileTooling.*;
+import static com.mxgraph.utils.FileUtils.EOL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Svg2JsTest {
+
+    private final Svg2Js xml2Js = new Svg2Js().infoLog(false).debugLog(false);
+
+    @Test
+    void process_svg_file() throws IOException {
+        File workingDirectory = destinationFolder("Svg2Js/work");
+
+        assertThat(xml2Js.convertToJsCode(svgSourceFile("simple-02/path-blue.svg"), workingDirectory))
+                .isEqualTo(toCode("// shape: path-blue",
+                        "// width: 70",
+                        "// height: 50",
+                        "// foreground",
+                        "canvas.begin();",
+                        "canvas.moveTo(0, 25);",
+                        "canvas.quadTo(20, 0, 30, 25);",
+                        "canvas.quadTo(40, 50, 70, 25);"
+                        )
+                );
+    }
+
+    private String toCode(String... lines) {
+        return String.join(EOL, lines);
+    }
+
+}

--- a/src/test/java/com/mxgraph/svg2js/Svg2JsTest.java
+++ b/src/test/java/com/mxgraph/svg2js/Svg2JsTest.java
@@ -25,7 +25,8 @@ class Svg2JsTest {
                         "canvas.begin();",
                         "canvas.moveTo(0, 25);",
                         "canvas.quadTo(20, 0, 30, 25);",
-                        "canvas.quadTo(40, 50, 70, 25);"
+                        "canvas.quadTo(40, 50, 70, 25);",
+                        "canvas.stroke();"
                         )
                 );
     }

--- a/src/test/java/com/mxgraph/svg2xml/Svg2XmlTest.java
+++ b/src/test/java/com/mxgraph/svg2xml/Svg2XmlTest.java
@@ -1,5 +1,7 @@
 package com.mxgraph.svg2xml;
 
+import static com.mxgraph.FileTooling.destinationFolder;
+import static com.mxgraph.FileTooling.svgSourceFiles;
 import static com.mxgraph.utils.FileUtils.EOL;
 import static com.mxgraph.utils.FileUtils.fileContent;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,9 +12,13 @@ import java.util.Arrays;
 
 class Svg2XmlTest {
 
+    private static Svg2Xml newSvg2Xml() {
+        return new Svg2Xml().infoLog(false);
+    }
+
     @Test
     void convertToXml_single_file() {
-        Svg2Xml svg2Xml = new Svg2Xml();
+        Svg2Xml svg2Xml = newSvg2Xml();
 
         File destPath = destinationFolder("Simple-Single file");
         svg2Xml.convertToXml(svgSourceFiles("simple-01/circle-green.svg"), destPath);
@@ -29,7 +35,7 @@ class Svg2XmlTest {
 
     @Test
     void convertToXml_two_files_from_the_same_folder() {
-        Svg2Xml svg2Xml = new Svg2Xml();
+        Svg2Xml svg2Xml = newSvg2Xml();
 
         File destPath = destinationFolder("Simple-Two files");
         svg2Xml.convertToXml(svgSourceFiles("simple-01/circle-green.svg", "simple-01/rectangle-blue.svg"), destPath);
@@ -48,7 +54,7 @@ class Svg2XmlTest {
 
     @Test
     void convertToXml_files_from_two_folders_without_subfolders_files_given_ordered_by_folders() {
-        Svg2Xml svg2Xml = new Svg2Xml();
+        Svg2Xml svg2Xml = newSvg2Xml();
 
         File destPath = destinationFolder("files from 2 folders - no subfolders");
         // in the current implementation, the files are supposed to be passed ordered by folder
@@ -70,28 +76,6 @@ class Svg2XmlTest {
                 "<quad x1=\"20\" x2=\"30\" y1=\"0\" y2=\"25\"/>",
                 "<quad x1=\"40\" x2=\"70\" y1=\"50\" y2=\"25\"/>"
         );
-    }
-
-    // =================================================================================================================
-    // UTILS
-    // =================================================================================================================
-
-    private static void assertFirstLine(String fileContent, String expectedStart, String expectedEnd) {
-        String firstLine = fileContent.substring(0, fileContent.indexOf(EOL));
-        assertThat(firstLine).describedAs("1st line of the generated file")
-                .startsWith(expectedStart)
-                .endsWith(expectedEnd);
-    }
-
-    private static File[] svgSourceFiles(String... fileNames) {
-        File parent = new File(System.getProperty("user.dir"), "src/test/resources/svg"); // ensure we pass absolute path
-        return Arrays.stream(fileNames)
-                .map(fileName -> new File(parent, fileName))
-                .toArray(File[]::new);
-    }
-
-    private static File destinationFolder(String folderName) {
-        return new File("target/test/output/", folderName);
     }
 
 }

--- a/src/test/java/com/mxgraph/xml2js/Xml2JsTest.java
+++ b/src/test/java/com/mxgraph/xml2js/Xml2JsTest.java
@@ -15,6 +15,7 @@ class Xml2JsTest {
                 .element("<curve x1='85.52' x2='39.66' x3='39.66' y1='0' y2='45.87' y3='102.25'/>")
                 .element("<line x='39.66' y='131.4'/>")
                 .element("<arc large-arc-flag='0' rx='6.43' ry='6.43' sweep-flag='1' x='95.51' x-axis-rotation='0' y='135.03'/>")
+                .element("<quad x1='20' x2='30' y1='0' y2='25'/>")
                 .element("<close/>")
                 .end()
         ;
@@ -30,6 +31,7 @@ class Xml2JsTest {
                 "canvas.curveTo(85.52, 0, 39.66, 45.87, 39.66, 102.25);",
                 "canvas.lineTo(39.66, 131.4);",
                 "canvas.arcTo(6.43, 6.43, 0, 0, 1, 95.51, 135.03);",
+                "canvas.quadTo(20, 0, 30, 25);",
                 "canvas.close();",
                 "canvas.fillAndStroke();"
         );

--- a/src/test/resources/svg/simple-02/path-blue.svg
+++ b/src/test/resources/svg/simple-02/path-blue.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" standalone="no"?>
-<svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+<svg width="250" height="350" version="1.1" xmlns="http://www.w3.org/2000/svg">
     <path d="M20,230 Q40,205 50,230 T90,230" fill="none" stroke="blue" stroke-width="5"/>
 </svg>


### PR DESCRIPTION
In addition
- log management improvement: when running Svg2Js, underlying Svg2Xml and Xml2Js
are using the same log levels
- Xml2Js produce debug logs when processing unsupported elements
- add tests for Svg2Js
- avoid logs in Svg2Xml tests
